### PR TITLE
docs: fix docs link for en in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Every moment, Every place. Your AI - `Everywhere`
   </h1>
 
   <p align="center">
-    <a href="https://everywhere.sylinko.com"><strong>Explore the docs »</strong></a>
+    <a href="https://everywhere.sylinko.com/en-US/"><strong>Explore the docs »</strong></a>
     <br />
     <br />
     <a href="https://github.com/DearVa/Everywhere">View Demo</a>
@@ -193,7 +193,7 @@ Every moment, Every place. Your AI - `Everywhere`
 
 ### Documents
 
-Visit here: [Official Docs](https://everywhere.sylinko.com)
+Visit here: [Official Docs](https://everywhere.sylinko.com/en-US/)
 
 Document is in development. Contributions are welcomed.
 


### PR DESCRIPTION
Because https://everywhere.sylinko.com/ redirects to https://everywhere.sylinko.com/zh-CN/

I replaced the docs link to https://everywhere.sylinko.com/en-US/