### PR TITLE
feat: add MiniMax as first-class LLM provider

### DIFF
--- a/README-zh-cn.md
+++ b/README-zh-cn.md
@@ -114,6 +114,7 @@
         • <img style="margin-top:3px;margin-bottom:-3px;" alt="Google logo" src="https://registry.npmmirror.com/@lobehub/icons-static-svg/latest/files/icons/gemini-color.svg"> Google (Gemini)<br>
         • <img style="margin-top:3px;margin-bottom:-3px;" alt="DeepSeek logo" src="https://registry.npmmirror.com/@lobehub/icons-static-svg/latest/files/icons/deepseek-color.svg"> DeepSeek<br>
         • <img style="margin-top:3px;margin-bottom:-3px;" alt="Moonshot logo" src="https://registry.npmmirror.com/@lobehub/icons-static-svg/latest/files/icons/moonshot.svg"> Moonshot (Kimi)<br>
+        • <img style="margin-top:3px;margin-bottom:-3px;" alt="MiniMax logo" src="https://registry.npmmirror.com/@lobehub/icons-static-svg/latest/files/icons/minimax-color.svg"> MiniMax<br>
         • <img style="margin-top:3px;margin-bottom:-3px;" alt="OpenRouter logo" src="https://registry.npmmirror.com/@lobehub/icons-static-svg/latest/files/icons/openrouter.svg"> OpenRouter<br>
         • <img style="margin-top:3px;margin-bottom:-3px;" alt="SiliconCloud logo" src="https://registry.npmmirror.com/@lobehub/icons-static-svg/latest/files/icons/siliconcloud-color.svg"> SiliconCloud<br>
         • <img style="margin-top:3px;margin-bottom:-3px;" alt="ollama logo" src="https://registry.npmmirror.com/@lobehub/icons-static-svg/latest/files/icons/ollama.svg"> Ollama<br>

--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ Every moment, Every place. Your AI - `Everywhere`
         • <img style="margin-top:3px;margin-bottom:-3px;" alt="Google logo" src="https://registry.npmmirror.com/@lobehub/icons-static-svg/latest/files/icons/gemini-color.svg"> Google (Gemini)<br>
         • <img style="margin-top:3px;margin-bottom:-3px;" alt="DeepSeek logo" src="https://registry.npmmirror.com/@lobehub/icons-static-svg/latest/files/icons/deepseek-color.svg"> DeepSeek<br>
         • <img style="margin-top:3px;margin-bottom:-3px;" alt="Moonshot logo" src="https://registry.npmmirror.com/@lobehub/icons-static-svg/latest/files/icons/moonshot.svg"> Moonshot (Kimi)<br>
+        • <img style="margin-top:3px;margin-bottom:-3px;" alt="MiniMax logo" src="https://registry.npmmirror.com/@lobehub/icons-static-svg/latest/files/icons/minimax-color.svg"> MiniMax<br>
         • <img style="margin-top:3px;margin-bottom:-3px;" alt="OpenRouter logo" src="https://registry.npmmirror.com/@lobehub/icons-static-svg/latest/files/icons/openrouter.svg"> OpenRouter<br>
         • <img style="margin-top:3px;margin-bottom:-3px;" alt="SiliconCloud logo" src="https://registry.npmmirror.com/@lobehub/icons-static-svg/latest/files/icons/siliconcloud-color.svg"> SiliconCloud<br>
         • <img style="margin-top:3px;margin-bottom:-3px;" alt="ollama logo" src="https://registry.npmmirror.com/@lobehub/icons-static-svg/latest/files/icons/ollama.svg"> Ollama<br>

--- a/src/Everywhere.Core/AI/CustomAssistant.cs
+++ b/src/Everywhere.Core/AI/CustomAssistant.cs
@@ -603,6 +603,50 @@ public sealed partial class PresetBasedModelProviderConfigurator(CustomAssistant
         },
         new()
         {
+            Id = "minimax",
+            DisplayName = "MiniMax",
+            Endpoint = "https://api.minimax.io/v1",
+            OfficialWebsiteUrl = "https://www.minimaxi.com",
+            DarkIconUrl = "avares://Everywhere.Core/Assets/Icons/minimax-color.svg",
+            LightIconUrl = "avares://Everywhere.Core/Assets/Icons/minimax-color.svg",
+            Schema = ModelProviderSchema.OpenAI,
+            ModelDefinitions =
+            [
+                new ModelDefinitionTemplate
+                {
+                    Id = "MiniMax-M2.7",
+                    ModelId = "MiniMax-M2.7",
+                    DisplayName = "MiniMax M2.7",
+                    MaxTokens = 1_000_000,
+                    IsImageInputSupported = false,
+                    IsFunctionCallingSupported = true,
+                    IsDeepThinkingSupported = true,
+                    IsDefault = true
+                },
+                new ModelDefinitionTemplate
+                {
+                    Id = "MiniMax-M2.7-highspeed",
+                    ModelId = "MiniMax-M2.7-highspeed",
+                    DisplayName = "MiniMax M2.7 Highspeed",
+                    MaxTokens = 1_000_000,
+                    IsImageInputSupported = false,
+                    IsFunctionCallingSupported = true,
+                    IsDeepThinkingSupported = true,
+                },
+                new ModelDefinitionTemplate
+                {
+                    Id = "MiniMax-M2.5-highspeed",
+                    ModelId = "MiniMax-M2.5-highspeed",
+                    DisplayName = "MiniMax M2.5 Highspeed",
+                    MaxTokens = 204_800,
+                    IsImageInputSupported = false,
+                    IsFunctionCallingSupported = true,
+                    IsDeepThinkingSupported = false,
+                }
+            ]
+        },
+        new()
+        {
             Id = "openrouter",
             DisplayName = "OpenRouter",
             OfficialWebsiteUrl = "https://openrouter.ai",
@@ -739,10 +783,10 @@ public sealed partial class PresetBasedModelProviderConfigurator(CustomAssistant
                 },
                 new ModelDefinitionTemplate
                 {
-                    Id = "MiniMaxAI/MiniMax-M2",
-                    ModelId = "MiniMaxAI/MiniMax-M2",
-                    DisplayName = "MiniMax M2",
-                    MaxTokens = 192_000,
+                    Id = "MiniMaxAI/MiniMax-M2.7",
+                    ModelId = "MiniMaxAI/MiniMax-M2.7",
+                    DisplayName = "MiniMax M2.7",
+                    MaxTokens = 1_000_000,
                     IsImageInputSupported = false,
                     IsFunctionCallingSupported = true,
                     IsDeepThinkingSupported = true

--- a/src/Everywhere.Core/Assets/Icons/minimax-color.svg
+++ b/src/Everywhere.Core/Assets/Icons/minimax-color.svg
@@ -1,0 +1,1 @@
+<svg height="1em" style="flex:none;line-height:1" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg"><title>MiniMax</title><path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-2.5 14.5v-9L12 10l2.5-2.5v9h-2v-5.17l-.5.5-.5-.5V16.5h-2z" fill="#1A6BFF"/></svg>

--- a/tests/Everywhere.Tests/AI/MiniMaxProviderTests.cs
+++ b/tests/Everywhere.Tests/AI/MiniMaxProviderTests.cs
@@ -1,0 +1,170 @@
+using Everywhere.AI;
+
+namespace Everywhere.Tests.AI;
+
+[TestFixture]
+public class MiniMaxProviderTests
+{
+    private ModelProviderTemplate _minimaxTemplate = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        // Access the MiniMax provider template via reflection since ModelProviderTemplates is private
+        var property = typeof(CustomAssistant).GetProperty(
+            "ModelProviderTemplates",
+            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
+        Assert.That(property, Is.Not.Null, "ModelProviderTemplates property should exist");
+
+        var templates = (ModelProviderTemplate[])property!.GetValue(null)!;
+        _minimaxTemplate = templates.First(t => t.Id == "minimax");
+    }
+
+    [Test]
+    public void MiniMaxTemplate_ShouldExist()
+    {
+        Assert.That(_minimaxTemplate, Is.Not.Null);
+    }
+
+    [Test]
+    public void MiniMaxTemplate_ShouldHaveCorrectDisplayName()
+    {
+        Assert.That(_minimaxTemplate.DisplayName, Is.EqualTo("MiniMax"));
+    }
+
+    [Test]
+    public void MiniMaxTemplate_ShouldUseOpenAISchema()
+    {
+        Assert.That(_minimaxTemplate.Schema, Is.EqualTo(ModelProviderSchema.OpenAI));
+    }
+
+    [Test]
+    public void MiniMaxTemplate_ShouldHaveCorrectEndpoint()
+    {
+        Assert.That(_minimaxTemplate.Endpoint, Is.EqualTo("https://api.minimax.io/v1"));
+    }
+
+    [Test]
+    public void MiniMaxTemplate_ShouldHaveOfficialWebsiteUrl()
+    {
+        Assert.That(_minimaxTemplate.OfficialWebsiteUrl, Is.EqualTo("https://www.minimaxi.com"));
+    }
+
+    [Test]
+    public void MiniMaxTemplate_ShouldHaveIconUrls()
+    {
+        using var scope = Assert.EnterMultipleScope();
+        Assert.That(_minimaxTemplate.DarkIconUrl, Is.Not.Null.And.Not.Empty);
+        Assert.That(_minimaxTemplate.LightIconUrl, Is.Not.Null.And.Not.Empty);
+    }
+
+    [Test]
+    public void MiniMaxTemplate_ShouldHaveThreeModels()
+    {
+        Assert.That(_minimaxTemplate.ModelDefinitions, Has.Count.EqualTo(3));
+    }
+
+    [Test]
+    public void MiniMaxTemplate_M27_ShouldBeDefault()
+    {
+        var m27 = _minimaxTemplate.ModelDefinitions.First(m => m.Id == "MiniMax-M2.7");
+        Assert.That(m27.IsDefault, Is.True);
+    }
+
+    [Test]
+    public void MiniMaxTemplate_M27_ShouldHaveCorrectProperties()
+    {
+        var m27 = _minimaxTemplate.ModelDefinitions.First(m => m.Id == "MiniMax-M2.7");
+
+        using var scope = Assert.EnterMultipleScope();
+        Assert.That(m27.ModelId, Is.EqualTo("MiniMax-M2.7"));
+        Assert.That(m27.DisplayName, Is.EqualTo("MiniMax M2.7"));
+        Assert.That(m27.MaxTokens, Is.EqualTo(1_000_000));
+        Assert.That(m27.IsImageInputSupported, Is.False);
+        Assert.That(m27.IsFunctionCallingSupported, Is.True);
+        Assert.That(m27.IsDeepThinkingSupported, Is.True);
+    }
+
+    [Test]
+    public void MiniMaxTemplate_M27Highspeed_ShouldHaveCorrectProperties()
+    {
+        var m27hs = _minimaxTemplate.ModelDefinitions.First(m => m.Id == "MiniMax-M2.7-highspeed");
+
+        using var scope = Assert.EnterMultipleScope();
+        Assert.That(m27hs.ModelId, Is.EqualTo("MiniMax-M2.7-highspeed"));
+        Assert.That(m27hs.DisplayName, Is.EqualTo("MiniMax M2.7 Highspeed"));
+        Assert.That(m27hs.MaxTokens, Is.EqualTo(1_000_000));
+        Assert.That(m27hs.IsFunctionCallingSupported, Is.True);
+        Assert.That(m27hs.IsDeepThinkingSupported, Is.True);
+        Assert.That(m27hs.IsDefault, Is.False);
+    }
+
+    [Test]
+    public void MiniMaxTemplate_M25Highspeed_ShouldHaveCorrectProperties()
+    {
+        var m25hs = _minimaxTemplate.ModelDefinitions.First(m => m.Id == "MiniMax-M2.5-highspeed");
+
+        using var scope = Assert.EnterMultipleScope();
+        Assert.That(m25hs.ModelId, Is.EqualTo("MiniMax-M2.5-highspeed"));
+        Assert.That(m25hs.DisplayName, Is.EqualTo("MiniMax M2.5 Highspeed"));
+        Assert.That(m25hs.MaxTokens, Is.EqualTo(204_800));
+        Assert.That(m25hs.IsFunctionCallingSupported, Is.True);
+        Assert.That(m25hs.IsDeepThinkingSupported, Is.False);
+        Assert.That(m25hs.IsDefault, Is.False);
+    }
+
+    [Test]
+    public void MiniMaxEndpoint_ShouldNormalizeCorrectly()
+    {
+        // MiniMax uses OpenAI schema, so endpoint normalization should follow OpenAI rules
+        var normalized = ModelProviderSchema.OpenAI.NormalizeEndpoint("https://api.minimax.io/v1");
+        Assert.That(normalized, Is.EqualTo("https://api.minimax.io/v1"));
+    }
+
+    [Test]
+    public void MiniMaxEndpoint_WithoutVersion_ShouldAppendV1()
+    {
+        var normalized = ModelProviderSchema.OpenAI.NormalizeEndpoint("https://api.minimax.io");
+        Assert.That(normalized, Is.EqualTo("https://api.minimax.io/v1"));
+    }
+
+    [Test]
+    public void MiniMaxEndpoint_PreviewEndpoint_ShouldBeChatCompletions()
+    {
+        var preview = ModelProviderSchema.OpenAI.PreviewEndpoint("https://api.minimax.io/v1");
+        Assert.That(preview, Is.EqualTo("https://api.minimax.io/v1/chat/completions"));
+    }
+
+    [Test]
+    public void SiliconCloud_ShouldHaveMiniMaxM27Model()
+    {
+        var property = typeof(CustomAssistant).GetProperty(
+            "ModelProviderTemplates",
+            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
+        var templates = (ModelProviderTemplate[])property!.GetValue(null)!;
+        var siliconcloud = templates.First(t => t.Id == "siliconcloud");
+
+        var minimaxModel = siliconcloud.ModelDefinitions.FirstOrDefault(m => m.Id == "MiniMaxAI/MiniMax-M2.7");
+        Assert.That(minimaxModel, Is.Not.Null, "SiliconCloud should have MiniMax M2.7 model");
+        Assert.That(minimaxModel!.MaxTokens, Is.EqualTo(1_000_000));
+    }
+
+    [Test]
+    public void AllProviderTemplates_ShouldHaveUniqueIds()
+    {
+        var property = typeof(CustomAssistant).GetProperty(
+            "ModelProviderTemplates",
+            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
+        var templates = (ModelProviderTemplate[])property!.GetValue(null)!;
+
+        var ids = templates.Select(t => t.Id).ToList();
+        Assert.That(ids, Is.Unique, "All provider template IDs should be unique");
+    }
+
+    [Test]
+    public void MiniMaxModelIds_ShouldBeUnique()
+    {
+        var ids = _minimaxTemplate.ModelDefinitions.Select(m => m.Id).ToList();
+        Assert.That(ids, Is.Unique);
+    }
+}


### PR DESCRIPTION
## Summary

- Add **MiniMax** as a first-class LLM provider with M2.7, M2.7-highspeed, and M2.5-highspeed models (up to 1M context window)
- MiniMax uses the OpenAI-compatible API, so it reuses the existing `OpenAIKernelMixin` — no new provider implementation needed
- Upgrade SiliconCloud MiniMax model from M2 to M2.7
- Add MiniMax SVG icon for the provider selector UI
- Add MiniMax to the supported LLM providers list in both READMEs (EN + ZH)
- Add 16 unit tests covering provider template configuration, model definitions, and endpoint normalization

## Details

**MiniMax** ([minimaxi.com](https://www.minimaxi.com)) is a leading AI company offering powerful language models via an OpenAI-compatible API at `https://api.minimax.io/v1`.

### Models added:
| Model | Context Window | Function Calling | Deep Thinking |
|-------|---------------|-----------------|---------------|
| MiniMax-M2.7 (default) | 1,000,000 | yes | yes |
| MiniMax-M2.7-highspeed | 1,000,000 | yes | yes |
| MiniMax-M2.5-highspeed | 204,800 | yes | no |

### Files changed:
- `src/Everywhere.Core/AI/CustomAssistant.cs` - MiniMax provider template + SiliconCloud M2 to M2.7 upgrade
- `src/Everywhere.Core/Assets/Icons/minimax-color.svg` - Provider icon
- `tests/Everywhere.Tests/AI/MiniMaxProviderTests.cs` - 16 unit tests
- `README.md` / `README-zh-cn.md` - Add MiniMax to LLM support list

## Test plan
- [ ] Verify MiniMax provider appears in the model provider selection UI
- [ ] Verify MiniMax models are listed correctly with proper capabilities
- [ ] Test chat completion with MiniMax M2.7 using an API key
- [ ] Run unit tests: `dotnet test tests/Everywhere.Tests`