### PR TITLE
feat: SessionExpired auto retry (#232)

### DIFF
--- a/src/Everywhere.Core/Chat/ChatService.cs
+++ b/src/Everywhere.Core/Chat/ChatService.cs
@@ -838,6 +838,34 @@ public sealed partial class ChatService : IChatService
 
             resultContent = await content.InvokeAsync(context.Kernel, cancellationToken);
         }
+        catch (Exception ex) when (context.ChatFunction is McpChatFunction && IsMcpSessionExpiredException(ex))
+        {
+
+            try
+            {
+                var mcpPlugin = _chatPluginManager.McpPlugins
+                    .AsValueEnumerable()
+                    .FirstOrDefault(p => p.Name == context.ChatPlugin.Name) ?? throw new InvalidOperationException($"MCP plugin '{context.ChatPlugin.Name}' not found for session recovery.");
+
+                await _chatPluginManager.StopMcpClientAsync(mcpPlugin);
+                await _chatPluginManager.StartMcpClientAsync(mcpPlugin, cancellationToken);
+
+                var newFunction = mcpPlugin.GetEnabledFunctions()
+                    .OfType<McpChatFunction>()
+                    .FirstOrDefault(f => f.KernelFunction.Name == content.FunctionName) ?? throw new InvalidOperationException($"Function '{content.FunctionName}' not found after MCP client restart.");
+                    
+                var kernelArgs = content.Arguments != null ? new KernelArguments(content.Arguments) : [];
+                var retryResult = await newFunction.KernelFunction.InvokeAsync(context.Kernel, kernelArgs, cancellationToken);
+                resultContent = new FunctionResultContent(content, retryResult);
+            }
+            catch (Exception retryEx)
+            {
+                retryEx = HandledFunctionInvokingException.Handle(retryEx);
+                activity?.SetStatus(ActivityStatusCode.Error, retryEx.Message);
+                _logger.LogError(retryEx, "MCP session recovery failed for function '{FunctionName}'", content.FunctionName);
+                resultContent = new FunctionResultContent(content, $"Error: {retryEx.Message}") { InnerContent = retryEx };
+            }
+        }
         catch (Exception ex)
         {
             ex = HandledFunctionInvokingException.Handle(ex);
@@ -909,6 +937,24 @@ public sealed partial class ChatService : IChatService
             return promise.Task;
 
         }
+    }
+
+    /// <summary>
+    /// Checks whether the exception indicates an MCP session has expired.
+    /// </summary>
+    private static bool IsMcpSessionExpiredException(Exception ex)
+    {
+        for (var current = ex; current != null; current = current.InnerException)
+        {
+            var message = current.Message;
+            if (message.Contains("Session", StringComparison.OrdinalIgnoreCase) &&
+                message.Contains("Expired", StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private async Task GenerateTitleAsync(

--- a/src/Everywhere.Core/Views/Pages/ChatPluginPage.axaml
+++ b/src/Everywhere.Core/Views/Pages/ChatPluginPage.axaml
@@ -388,7 +388,7 @@
                           Classes="Ghost" Width="32"
                           Padding="0"
                           Command="{Binding #Self.ViewModel.CopyLogsCommand}"
-                          CommandParameter="{Binding}"
+                          CommandParameter="{Binding #Self.ViewModel.SelectedMcpPlugin}"
                           Content="{LucideIconContent Copy, Size=16}"
                           ToolTip.Tip="{I18N {x:Static LocaleKey.ChatPluginPage_CopyLogsButton_ToolTip}}"/>
                         <ToggleSwitch


### PR DESCRIPTION
## Description
This PR adds transparent MCP session-expired recovery for HTTP MCP tool calls. When the server returns a session expiration error, the client now restarts the MCP plugin and retries the tool call once automatically.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation update
- [ ] CI/CD or Build changes

## Current Behavior
like issue #232 

## Updated/Expected Behavior
When a session-expired MCP error is detected, the MCP client is restarted automatically and the tool call is retried once. If the retry succeeds, the user and AI receive the successful result without seeing the transient failure.

## Implementation Details
- Added session-expired detection in `ChatService` for MCP function invocation failures.

## Checklist
- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] I have added XML documentation to any related classes

## Fixed Issues
Fixes #232 