### PR TITLE
fix: correct image support badge tooltip text

### DIFF
--- a/src/Everywhere.Core/Assets/DataTemplates.axaml
+++ b/src/Everywhere.Core/Assets/DataTemplates.axaml
@@ -136,7 +136,7 @@
         <shadui:Badge
           Background="Chocolate"
           IsVisible="{Binding InputModalities, Converter={x:Static vc:ModalitiesConverters.SupportsImage}}"
-          ToolTip.Tip="{I18N {x:Static LocaleKey.CustomAssistant_SupportsReasoning_Header}}">
+          ToolTip.Tip="{I18N {x:Static LocaleKey.CustomAssistant_SupportsImage_Header}}">
           <LucideIcon Kind="Eye"/>
         </shadui:Badge>
         <shadui:Badge

--- a/src/Everywhere.Core/Views/Cloud/OfficialModelDefinitionForm.axaml
+++ b/src/Everywhere.Core/Views/Cloud/OfficialModelDefinitionForm.axaml
@@ -137,7 +137,7 @@
                         <shadui:Badge
                           Background="Chocolate"
                           IsVisible="{Binding InputModalities, Converter={x:Static vc:ModalitiesConverters.SupportsImage}}"
-                          ToolTip.Tip="{I18N {x:Static LocaleKey.CustomAssistant_SupportsReasoning_Header}}">
+                          ToolTip.Tip="{I18N {x:Static LocaleKey.CustomAssistant_SupportsImage_Header}}">
                           <LucideIcon Kind="Eye"/>
                         </shadui:Badge>
                         <shadui:Badge

--- a/src/Everywhere.I18N/Strings.de.resx
+++ b/src/Everywhere.I18N/Strings.de.resx
@@ -535,6 +535,9 @@
     <data name="CustomAssistant_SupportsReasoning_Header" xml:space="preserve">
         <value>Tiefes Denken</value>
     </data>
+    <data name="CustomAssistant_SupportsImage_Header" xml:space="preserve">
+        <value>Bildeingabe-Unterstützung</value>
+    </data>
     <data name="CustomAssistant_ContextLimit_Description" xml:space="preserve">
         <value>Maximale Kontextlänge der Konversation (context_limit). Dies beeinflusst die Strategie zum Aufbau des visuellen Kontexts, bitte so realistisch wie möglich einstellen.</value>
     </data>

--- a/src/Everywhere.I18N/Strings.es.resx
+++ b/src/Everywhere.I18N/Strings.es.resx
@@ -536,6 +536,9 @@
     <data name="CustomAssistant_SupportsReasoning_Header" xml:space="preserve">
         <value>Pensamiento Profundo</value>
     </data>
+    <data name="CustomAssistant_SupportsImage_Header" xml:space="preserve">
+        <value>Soporte de Entrada de Imagen</value>
+    </data>
     <data name="CustomAssistant_ContextLimit_Description" xml:space="preserve">
         <value>Longitud máxima del contexto de la conversación (context_limit). Esto afectará la estrategia para construir el contexto visual, por favor establece un valor real si es posible.</value>
     </data>

--- a/src/Everywhere.I18N/Strings.fr.resx
+++ b/src/Everywhere.I18N/Strings.fr.resx
@@ -536,6 +536,9 @@
     <data name="CustomAssistant_SupportsReasoning_Header" xml:space="preserve">
         <value>Réflexion approfondie</value>
     </data>
+    <data name="CustomAssistant_SupportsImage_Header" xml:space="preserve">
+        <value>Support d'Entrée d'Image</value>
+    </data>
     <data name="CustomAssistant_ContextLimit_Description" xml:space="preserve">
         <value>Longueur maximale du contexte de la conversation (context_limit). Cela influencera la stratégie de construction du contexte visuel, veuillez le définir autant que possible à une valeur réelle.</value>
     </data>

--- a/src/Everywhere.I18N/Strings.it.resx
+++ b/src/Everywhere.I18N/Strings.it.resx
@@ -536,6 +536,9 @@
     <data name="CustomAssistant_SupportsReasoning_Header" xml:space="preserve">
         <value>Pensiero Profondo</value>
     </data>
+    <data name="CustomAssistant_SupportsImage_Header" xml:space="preserve">
+        <value>Supporto Input Immagine</value>
+    </data>
     <data name="CustomAssistant_ContextLimit_Description" xml:space="preserve">
         <value>Lunghezza massima del contesto della conversazione (context_limit). Questo influenzerà la strategia per costruire il contesto visivo, impostalo il più possibile su un valore reale.</value>
     </data>

--- a/src/Everywhere.I18N/Strings.ja.resx
+++ b/src/Everywhere.I18N/Strings.ja.resx
@@ -536,6 +536,9 @@
     <data name="CustomAssistant_SupportsReasoning_Header" xml:space="preserve">
         <value>深い思考</value>
     </data>
+    <data name="CustomAssistant_SupportsImage_Header" xml:space="preserve">
+        <value>画像入力サポート</value>
+    </data>
     <data name="CustomAssistant_ContextLimit_Description" xml:space="preserve">
         <value>対話の最大コンテキスト長 (context_limit)。これは視覚的コンテキストを構築する戦略に影響を与えるため、できるだけ実際の値に設定してください。</value>
     </data>

--- a/src/Everywhere.I18N/Strings.ko.resx
+++ b/src/Everywhere.I18N/Strings.ko.resx
@@ -536,6 +536,9 @@
     <data name="CustomAssistant_SupportsReasoning_Header" xml:space="preserve">
         <value>심층 사고</value>
     </data>
+    <data name="CustomAssistant_SupportsImage_Header" xml:space="preserve">
+        <value>이미지 입력 지원</value>
+    </data>
     <data name="CustomAssistant_ContextLimit_Description" xml:space="preserve">
         <value>대화의 최대 컨텍스트 길이 (context_limit). 이 값은 시각적 컨텍스트를 구축하는 전략에 영향을 미치므로 가능한 실제 값으로 설정하세요.</value>
     </data>

--- a/src/Everywhere.I18N/Strings.resx
+++ b/src/Everywhere.I18N/Strings.resx
@@ -536,6 +536,9 @@
     <data name="CustomAssistant_SupportsReasoning_Header" xml:space="preserve">
         <value>Deep Thinking</value>
     </data>
+    <data name="CustomAssistant_SupportsImage_Header" xml:space="preserve">
+        <value>Image Input Support</value>
+    </data>
     <data name="CustomAssistant_ContextLimit_Description" xml:space="preserve">
         <value>Maximum context length for the conversation (context_limit). This will affect the strategy for building visual context, so please set it to a realistic value.</value>
     </data>

--- a/src/Everywhere.I18N/Strings.ru.resx
+++ b/src/Everywhere.I18N/Strings.ru.resx
@@ -536,6 +536,9 @@
     <data name="CustomAssistant_SupportsReasoning_Header" xml:space="preserve">
         <value>Глубокое Мышление</value>
     </data>
+    <data name="CustomAssistant_SupportsImage_Header" xml:space="preserve">
+        <value>Поддержка Ввода Изображения</value>
+    </data>
     <data name="CustomAssistant_ContextLimit_Description" xml:space="preserve">
         <value>Максимальная длина контекста диалога (context_limit). Это повлияет на стратегию построения визуального контекста, постарайтесь установить реальное значение.</value>
     </data>

--- a/src/Everywhere.I18N/Strings.tr.resx
+++ b/src/Everywhere.I18N/Strings.tr.resx
@@ -535,6 +535,9 @@
     <data name="CustomAssistant_SupportsReasoning_Header" xml:space="preserve">
         <value>Derin Düşünme</value>
     </data>
+    <data name="CustomAssistant_SupportsImage_Header" xml:space="preserve">
+        <value>Görsel Giriş Desteği</value>
+    </data>
     <data name="CustomAssistant_ContextLimit_Description" xml:space="preserve">
         <value>Sohbetin maksimum bağlam uzunluğu (context_limit). Bu, görsel bağlam oluşturma stratejisini etkiler, mümkünse gerçek bir değer olarak ayarlayın.</value>
     </data>

--- a/src/Everywhere.I18N/Strings.zh-hans.resx
+++ b/src/Everywhere.I18N/Strings.zh-hans.resx
@@ -536,6 +536,9 @@
     <data name="CustomAssistant_SupportsReasoning_Header" xml:space="preserve">
         <value>深度思考</value>
     </data>
+    <data name="CustomAssistant_SupportsImage_Header" xml:space="preserve">
+        <value>图像输入支持</value>
+    </data>
     <data name="CustomAssistant_ContextLimit_Description" xml:space="preserve">
         <value>对话的最大上下文长度 (context_limit)。此项会影响构建视觉上下文的策略，请尽可能设为真实值。</value>
     </data>

--- a/src/Everywhere.I18N/Strings.zh-hant-hk.resx
+++ b/src/Everywhere.I18N/Strings.zh-hant-hk.resx
@@ -536,6 +536,9 @@
     <data name="CustomAssistant_SupportsReasoning_Header" xml:space="preserve">
         <value>深度思考</value>
     </data>
+    <data name="CustomAssistant_SupportsImage_Header" xml:space="preserve">
+        <value>圖像輸入支援</value>
+    </data>
     <data name="CustomAssistant_ContextLimit_Description" xml:space="preserve">
         <value>對話的最大上下文長度。此項會影響構建視覺上下文的策略，請盡可能設為真實值。</value>
     </data>

--- a/src/Everywhere.I18N/Strings.zh-hant.resx
+++ b/src/Everywhere.I18N/Strings.zh-hant.resx
@@ -536,6 +536,9 @@
     <data name="CustomAssistant_SupportsReasoning_Header" xml:space="preserve">
         <value>深度思考</value>
     </data>
+    <data name="CustomAssistant_SupportsImage_Header" xml:space="preserve">
+        <value>圖像輸入支援</value>
+    </data>
     <data name="CustomAssistant_ContextLimit_Description" xml:space="preserve">
         <value>對話的最大上下文長度 (context_limit)。此項會影響構建視覺上下文的策略，請盡可能設為真實值。</value>
     </data>


### PR DESCRIPTION
- fix image support badge displaying wrong reasoning tooltip text
- add new locale key CustomAssistant_SupportsImage_Header across all supported languages (en, de, es, fr, it, ja, ko, ru, tr, zh-hans, zh-hant, zh-hant-hk)

## Description
This PR corrects the tooltip text displayed on the image support badge. Previously, the badge was incorrectly showing the reasoning tooltip instead of the image support tooltip.

## Type of Change
<!-- Please check the one that applies to this PR using "x". -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation update
- [ ] CI/CD or Build changes

## Current Behavior
The image support badge was displaying the wrong tooltip text - it showed the reasoning tooltip ("Deep thinking") instead of indicating image support.

## Updated/Expected Behavior
The image support badge now correctly displays the tooltip indicating image support capability across all 11 supported languages.

## Implementation Details
- Replaced `CustomAssistant_SupportsReasoning_Header` with `CustomAssistant_SupportsImage_Header` in the image support badge tooltip
- Added the new locale key `CustomAssistant_SupportsImage_Header` to all supported language resource files

## Screenshots / Recordings


## Checklist
- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [ ] I have added XML documentation to any related classes

## Breaking Changes
None

## Obsoletions / Deprecations
None

## Fixed Issues
None