### PR TITLE
Fix crash when MCP plugins are persisted with Guid.Empty as Id

### DIFF
--- a/src/Everywhere.Core/Configuration/Settings/PluginSettings.cs
+++ b/src/Everywhere.Core/Configuration/Settings/PluginSettings.cs
@@ -1,4 +1,4 @@
-﻿using System.Text.Json.Serialization;
+using System.Text.Json.Serialization;
 using CommunityToolkit.Mvvm.ComponentModel;
 using Everywhere.Chat.Plugins;
 using Everywhere.Collections;
@@ -75,6 +75,11 @@ public partial class McpChatPluginEntity : ObservableObject
         {
             return null;
         }
+
+        // Self-heal persisted Guid.Empty IDs; they cause KernelPluginCollection to throw
+        // a duplicate-key ArgumentException when two or more zero-ID plugins are loaded.
+        if (Id == Guid.Empty)
+            Id = Guid.CreateVersion7();
 
         return new McpChatPlugin(Id, transportConfiguration);
     }


### PR DESCRIPTION
## Problem

`KernelPluginCollection` uses the plugin `Name` (derived from `Id.ToString("N")`) as its dictionary key. When two or more `McpChatPluginEntity` records in settings have `Id == Guid.Empty`, the second `Add` call throws:

```
System.ArgumentException: Argument_AddingDuplicateWithKey, 00000000000000000000000000000000
   at System.Collections.Generic.Dictionary`2.Add(TKey key, TValue value)
   at Microsoft.SemanticKernel.KernelPluginCollection.Add(KernelPlugin plugin)
   at Everywhere.Chat.ChatService.BuildKernelAsync(...)
```

Every chat request fails with "An unknown error occurred" until the app is restarted with healed settings.

## Root cause

`McpChatPluginEntity.ToMcpChatPlugin()` passes `Id` directly to the `McpChatPlugin` constructor without checking for `Guid.Empty`. If settings were ever written with un-initialised IDs (e.g. by a migration or external edit), all such entries produce the same plugin name and the second one crashes the kernel builder.

## Fix

Self-heal on load: if `Id == Guid.Empty`, assign `Guid.CreateVersion7()` before constructing the plugin. The healed value is written back to settings on the next save (via the existing `SourceList → McpChatPluginEntity` binding in `ChatPluginManager`), so the repair is permanent.

```csharp
public McpChatPlugin? ToMcpChatPlugin()
{
    var transportConfiguration = Stdio as McpTransportConfiguration ?? Http;
    if (transportConfiguration == null) return null;

    // Self-heal persisted Guid.Empty IDs; they cause KernelPluginCollection to throw
    // a duplicate-key ArgumentException when two or more zero-ID plugins are loaded.
    if (Id == Guid.Empty)
        Id = Guid.CreateVersion7();

    return new McpChatPlugin(Id, transportConfiguration);
}
```

**Not changed:** the `[JsonConstructor]` path — initialising `Id` there would assign a fresh GUID to every record on every deserialization, breaking round-trips for records that already have a valid Id.