### PR TITLE
feat: add {DefaultSystemPrompt} prompt variable with recursive resolution

### DIFF
--- a/src/Everywhere.Core/Chat/ChatContext.cs
+++ b/src/Everywhere.Core/Chat/ChatContext.cs
@@ -6,6 +6,7 @@ using Avalonia.Threading;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Messaging;
 using DynamicData;
+using Everywhere.AI;
 using Everywhere.Collections;
 using Everywhere.Chat.Permissions;
 using Everywhere.Chat.Plugins;
@@ -496,6 +497,7 @@ public sealed partial class ChatContext : ObservableObject, IObservableList<Chat
             new KeyValuePair<string, Func<string>>("OS", () => Environment.OSVersion.ToString()),
             new KeyValuePair<string, Func<string>>("SystemLanguage", () => LocaleManager.CurrentLocale.ToEnglishName()),
             new KeyValuePair<string, Func<string>>("WorkingDirectory", EnsureWorkingDirectory),
+            new KeyValuePair<string, Func<string>>("DefaultSystemPrompt", () => Prompts.DefaultSystemPrompt),
         ]);
     }
 }

--- a/src/Everywhere.Core/Chat/ChatService.cs
+++ b/src/Everywhere.Core/Chat/ChatService.cs
@@ -1,7 +1,6 @@
 ﻿using System.Diagnostics;
 using System.Diagnostics.Metrics;
 using System.Text;
-using System.Text.RegularExpressions;
 using Avalonia.Threading;
 using CommunityToolkit.Mvvm.Messaging;
 using DynamicData;
@@ -1103,16 +1102,12 @@ public sealed partial class ChatService : IChatService
     #endregion
 
     // TODO: this is shit
-    private sealed partial class ScopedPromptRenderer(
+    private sealed class ScopedPromptRenderer(
         IDictionary<string, Func<string>> promptVariables
     ) : IPromptRenderer
     {
-        public static string RenderPrompt(string prompt, Func<string, string?> resolver)
-        {
-            return PromptTemplateRegex().Replace(
-                prompt,
-                m => resolver(m.Groups[1].Value) ?? m.Value);
-        }
+        public static string RenderPrompt(string prompt, Func<string, string?> resolver) =>
+            PromptTemplateRenderer.Render(prompt, resolver);
 
         public string RenderSystemPrompt(string prompt)
         {
@@ -1140,8 +1135,5 @@ public sealed partial class ChatService : IChatService
                 .Append(userInput)
                 .ToString();
         }
-
-        [GeneratedRegex(@"(?<!\{)\{(\w+)\}(?!\})")]
-        private static partial Regex PromptTemplateRegex();
     }
 }

--- a/src/Everywhere.Core/Chat/PromptTemplateRenderer.cs
+++ b/src/Everywhere.Core/Chat/PromptTemplateRenderer.cs
@@ -1,0 +1,63 @@
+using System.Text.RegularExpressions;
+
+namespace Everywhere.Chat;
+
+/// <summary>
+/// Resolves <c>{Variable}</c> placeholders in a prompt template against a resolver, recursively
+/// expanding placeholders that appear inside resolved values. This lets a value such as
+/// <see cref="Everywhere.AI.Prompts.DefaultSystemPrompt"/> (injected via the <c>{DefaultSystemPrompt}</c>
+/// variable) have its own inner <c>{OS}</c>/<c>{Date}</c>/... placeholders resolved as well.
+/// Resolution is guarded against infinite recursion.
+/// </summary>
+internal static partial class PromptTemplateRenderer
+{
+    /// <summary>
+    /// Backstop limit on recursion depth. The path-scoped cycle guard is the primary protection;
+    /// this additionally bounds stack/CPU for pathologically deep (but acyclic) variable chains.
+    /// </summary>
+    internal const int MaxDepth = 16;
+
+    /// <summary>
+    /// Renders <paramref name="template"/>, replacing each <c>{Name}</c> with <c>resolver(Name)</c>
+    /// and recursively resolving any placeholders inside the substituted values.
+    /// </summary>
+    /// <param name="template">The prompt template containing <c>{Name}</c> placeholders.</param>
+    /// <param name="resolver">
+    /// Resolves a variable name to its value, or <see langword="null"/> if unknown. Unknown
+    /// placeholders are left literal. Escaped <c>{{...}}</c> is never matched.
+    /// </param>
+    /// <returns>The fully resolved prompt.</returns>
+    internal static string Render(string template, Func<string, string?> resolver) =>
+        Expand(template, resolver, new HashSet<string>(StringComparer.Ordinal), 0);
+
+    /// <summary>
+    /// Single recursive expansion pass. The top-level template is matched once; recursion descends
+    /// only into the resolved value of each match.
+    /// </summary>
+    private static string Expand(string text, Func<string, string?> resolver, HashSet<string> visiting, int depth)
+    {
+        return PromptTemplateRegex().Replace(
+            text,
+            match =>
+            {
+                var name = match.Groups[1].Value;
+                var value = resolver(name);
+                if (value is null) return match.Value;       // unknown variable -> leave the literal {Name}
+                if (value.IndexOf('{') < 0) return value;    // leaf value (no placeholders) -> no recursion
+                if (depth >= MaxDepth) return value;         // depth backstop -> substitute once, stop
+                if (!visiting.Add(name)) return match.Value; // cycle on the current path -> leave literal
+                try
+                {
+                    return Expand(value, resolver, visiting, depth + 1);
+                }
+                finally
+                {
+                    // Pop so sibling/repeat occurrences at the same level still expand.
+                    visiting.Remove(name);
+                }
+            });
+    }
+
+    [GeneratedRegex(@"(?<!\{)\{(\w+)\}(?!\})")]
+    private static partial Regex PromptTemplateRegex();
+}

--- a/tests/Everywhere.Core.Tests/PromptTemplateRendererTests.cs
+++ b/tests/Everywhere.Core.Tests/PromptTemplateRendererTests.cs
@@ -1,0 +1,168 @@
+using Everywhere.AI;
+using Everywhere.Chat;
+
+namespace Everywhere.Core.Tests;
+
+/// <summary>
+/// Tests for <see cref="PromptTemplateRenderer.Render"/>, the recursive prompt-variable resolver.
+/// Covers issue #291: a custom system prompt can include the built-in default via the
+/// {DefaultSystemPrompt} variable, which is resolved recursively so the placeholders inside the
+/// default prompt ({OS}/{Date}/...) are also expanded — with infinite-recursion protection.
+/// </summary>
+public class PromptTemplateRendererTests
+{
+    private static Func<string, string?> Resolver(Dictionary<string, string?> map) =>
+        key => map.TryGetValue(key, out var value) ? value : null;
+
+    private static Dictionary<string, string?> Map(params (string Key, string? Value)[] entries)
+    {
+        var dict = new Dictionary<string, string?>(StringComparer.Ordinal);
+        foreach (var (key, value) in entries) dict[key] = value;
+        return dict;
+    }
+
+    // Resolver mimicking ChatContext.GetPromptVariables() + the new DefaultSystemPrompt variable.
+    private static Func<string, string?> DefaultPromptResolver() => Resolver(Map(
+        ("DefaultSystemPrompt", Prompts.DefaultSystemPrompt),
+        ("OS", "Windows"),
+        ("Date", "Monday"),
+        ("SystemLanguage", "English"),
+        ("WorkingDirectory", "C:/wd")));
+
+    private static string ResolvedDefault() => Prompts.DefaultSystemPrompt
+        .Replace("{OS}", "Windows")
+        .Replace("{Date}", "Monday")
+        .Replace("{SystemLanguage}", "English")
+        .Replace("{WorkingDirectory}", "C:/wd");
+
+    [Test]
+    public void Render_LeafVariable_ResolvesSinglePass()
+    {
+        var result = PromptTemplateRenderer.Render("{Date}", Resolver(Map(("Date", "Monday"))));
+        Assert.That(result, Is.EqualTo("Monday"));
+    }
+
+    [Test]
+    public void Render_UnknownVariable_LeftLiteral()
+    {
+        var result = PromptTemplateRenderer.Render("{Foo}", _ => null);
+        Assert.That(result, Is.EqualTo("{Foo}"));
+    }
+
+    [Test]
+    public void Render_EscapedDoubleBrace_StaysLiteral()
+    {
+        var result = PromptTemplateRenderer.Render("{{OS}}", Resolver(Map(("OS", "Windows"))));
+        Assert.That(result, Is.EqualTo("{{OS}}"));
+    }
+
+    [Test]
+    public void Render_TripleBrace_StaysLiteral()
+    {
+        var result = PromptTemplateRenderer.Render("{{{OS}}}", Resolver(Map(("OS", "Windows"))));
+        Assert.That(result, Is.EqualTo("{{{OS}}}"));
+    }
+
+    [Test]
+    public void Render_EscapedNextToReal_OnlyRealResolves()
+    {
+        var result = PromptTemplateRenderer.Render("{{OS}} {OS}", Resolver(Map(("OS", "Windows"))));
+        Assert.That(result, Is.EqualTo("{{OS}} Windows"));
+    }
+
+    [Test]
+    public void Render_DefaultSystemPrompt_ExpandsNestedLeafVariables()
+    {
+        var result = PromptTemplateRenderer.Render("{DefaultSystemPrompt}", DefaultPromptResolver());
+        Assert.That(result, Is.EqualTo(ResolvedDefault()));
+        Assert.That(result, Does.Not.Contain("{OS}"));
+        Assert.That(result, Does.Not.Contain("{Date}"));
+    }
+
+    [Test]
+    public void Render_CustomPromptWithDefaultPlaceholder_AppendsResolvedDefault()
+    {
+        var result = PromptTemplateRenderer.Render(
+            "Rules.\n\n{DefaultSystemPrompt}\n\nExtra.",
+            DefaultPromptResolver());
+        Assert.That(result, Is.EqualTo("Rules.\n\n" + ResolvedDefault() + "\n\nExtra."));
+    }
+
+    [Test]
+    public void Render_DefaultSystemPromptTwice_BothFullyExpand()
+    {
+        var result = PromptTemplateRenderer.Render("{DefaultSystemPrompt}|{DefaultSystemPrompt}", DefaultPromptResolver());
+        Assert.That(result, Is.EqualTo(ResolvedDefault() + "|" + ResolvedDefault()));
+    }
+
+    [Test]
+    public void Render_SelfReferentialValue_BreaksWithoutHang()
+    {
+        var result = PromptTemplateRenderer.Render("{A}", Resolver(Map(("A", "loop {A} end"))));
+        Assert.That(result, Is.EqualTo("loop {A} end"));
+    }
+
+    [Test]
+    public void Render_MutualCycle_TerminatesLeavingLiteral()
+    {
+        var result = PromptTemplateRenderer.Render("{A}", Resolver(Map(("A", "a={B}"), ("B", "b={A}"))));
+        Assert.That(result, Is.EqualTo("a=b={A}"));
+    }
+
+    [Test]
+    public void Render_RepeatedNonNestedVariable_ResolvesEachTime()
+    {
+        var result = PromptTemplateRenderer.Render("{X} and {X}", Resolver(Map(("X", "v"))));
+        Assert.That(result, Is.EqualTo("v and v"));
+    }
+
+    [Test]
+    public void Render_DepthCapExceeded_StopsGracefully()
+    {
+        // A finite-but-too-deep, non-cyclic chain V0 -> {V1} -> {V2} -> ... longer than MaxDepth.
+        var map = new Dictionary<string, string?>(StringComparer.Ordinal);
+        var chainLength = PromptTemplateRenderer.MaxDepth + 5;
+        for (var i = 0; i <= chainLength; i++) map["V" + i] = "{V" + (i + 1) + "}";
+
+        string result = string.Empty;
+        Assert.That(() => result = PromptTemplateRenderer.Render("{V0}", Resolver(map)), Throws.Nothing);
+        // Degrades gracefully: stops at the cap leaving an unresolved placeholder rather than looping.
+        Assert.That(result, Does.Contain("{"));
+    }
+
+    [Test]
+    public void Render_TitleResolver_DoesNotLeakUnknownVariables()
+    {
+        // The title generation resolver only knows {UserMessage}/{SystemLanguage}; a user-typed {Date}
+        // inside the message must stay literal even under recursion (returns null -> left as-is).
+        var resolver = Resolver(Map(("UserMessage", "hi {Date}"), ("SystemLanguage", "English")));
+        var result = PromptTemplateRenderer.Render(Prompts.TitleGeneratorUserPrompt, resolver);
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Does.Contain("hi {Date}"));   // inner unknown placeholder preserved
+            Assert.That(result, Does.Contain("English"));
+            Assert.That(result, Does.Not.Contain("{UserMessage}"));
+            Assert.That(result, Does.Not.Contain("{SystemLanguage}"));
+        });
+    }
+
+    [Test]
+    public void Render_ResolvedValueWithKnownPlaceholder_ExpandsRecursively()
+    {
+        // Documents the deliberate behavior delta: when a resolved value itself contains a placeholder
+        // the resolver knows, recursion expands it (e.g. a strategy {Argument} containing {OS}).
+        var resolver = Resolver(Map(("Argument", "open {OS} now"), ("OS", "Windows")));
+        var result = PromptTemplateRenderer.Render("Do {Argument}", resolver);
+        Assert.That(result, Is.EqualTo("Do open Windows now"));
+    }
+
+    [Test]
+    public void Render_UserTextWithKnownAndUnknownPlaceholders_ExpandsOnlyKnown()
+    {
+        // Pins the user-input recursion contract on a title-style resolver that knows {SystemLanguage}
+        // but not {OS}: a known inner placeholder expands; an unknown one is left literal.
+        var resolver = Resolver(Map(("UserMessage", "lang {SystemLanguage}, os {OS}"), ("SystemLanguage", "English")));
+        var result = PromptTemplateRenderer.Render("{UserMessage}", resolver);
+        Assert.That(result, Is.EqualTo("lang English, os {OS}"));
+    }
+}


### PR DESCRIPTION
## Description

Resolves #291, reworked per review. Instead of a per-assistant toggle, this adds a `{DefaultSystemPrompt}` prompt variable so a custom system prompt can include/append the built-in default by writing `{DefaultSystemPrompt}`, and makes prompt-variable resolution recursive so the placeholders inside the default prompt (`{OS}`/`{Date}`/...) also resolve.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Current Behavior

A custom assistant's System Prompt fully replaces the built-in default, with no way to reuse/extend the default without copying it by hand. Prompt variables were resolved in a single pass, so a value that itself contained placeholders was not expanded.

## Updated/Expected Behavior

- New `DefaultSystemPrompt` variable in `ChatContext.GetPromptVariables()` (`() => Prompts.DefaultSystemPrompt`). A user writes `{DefaultSystemPrompt}` in their System Prompt to include the default, then adds their own instructions around it.
- Variable resolution is now recursive, so the `{OS}`/`{Date}`/`{SystemLanguage}`/`{WorkingDirectory}` placeholders inside the injected default also resolve.
- Additive and non-breaking: no new setting/UI, and the common-case output is byte-identical to before.

To test: Settings -> Custom Assistant -> set System Prompt to `{DefaultSystemPrompt}` followed by a blank line and your own instruction (e.g. `Always answer in French.`). The model receives the fully-rendered default prompt followed by your instruction.

## Implementation Details

- Extracted the renderer core from the private nested `ScopedPromptRenderer` into an internal `PromptTemplateRenderer.Render` (unit-testable via `InternalsVisibleTo`); `RenderPrompt` delegates to it. The top-level template is still a single regex pass; recursion descends only into each resolved value.
- Infinite-recursion prevention: a path-scoped visiting-set (Ordinal) detects self/mutual cycles (the looping `{Name}` is left literal) plus a `MaxDepth = 16` backstop (substitute-once at the cap). Never throws -- matches the existing unknown-variable-stays-literal contract. Escaped `{{...}}` stays literal at every level; a leaf-value fast path keeps the common case byte-identical.
- Added `PromptTemplateRendererTests` (15 NUnit cases): nested expansion, the append scenario, repeated/twice expansion, self & mutual cycles, depth cap, escaped/triple braces, unknown vars, and the user-input known/unknown placeholder contract.

## Behavior nuance (for your call)

Resolution is now a single shared recursive engine (per your suggestion), so the strategy-prompt path also re-scans a substituted `{Argument}` (raw user input) / preprocessor values -- e.g. a user literally typing `{OS}` in a strategy message would have it expanded. The cycle guard prevents `{Argument}` self-loops and the trailing raw `<UserRequestStart>` copy of the user input is appended after rendering (never processed). If you'd prefer user-origin values to stay opaque, that's a one-line guard -- happy to add it.

## Checklist

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] I have added XML documentation to any related classes

## Fixed Issues

Fixes #291