### PR TITLE
fix: support Claude Opus 4.8 adaptive thinking

### DIFF
--- a/src/Everywhere.Core/AI/AnthropicKernelMixin.cs
+++ b/src/Everywhere.Core/AI/AnthropicKernelMixin.cs
@@ -47,6 +47,7 @@ public sealed partial class AnthropicKernelMixin : KernelMixin
         private readonly bool _isClaude;
         private readonly bool _isClaude46;
         private readonly bool _isClaude47;
+        private readonly bool _isClaude48;
 
         public OptimizedChatClient(IChatClient originalClient, AnthropicKernelMixin owner) : base(originalClient)
         {
@@ -54,6 +55,7 @@ public sealed partial class AnthropicKernelMixin : KernelMixin
             _isClaude = owner.ModelId.Contains("claude", StringComparison.OrdinalIgnoreCase);
             _isClaude46 = _isClaude && Claude46Regex().IsMatch(owner.ModelId);
             _isClaude47 = _isClaude && Claude47Regex().IsMatch(owner.ModelId);
+            _isClaude48 = _isClaude && Claude48Regex().IsMatch(owner.ModelId);
         }
 
         private void BuildOptions(ref ChatOptions? options)
@@ -73,31 +75,43 @@ public sealed partial class AnthropicKernelMixin : KernelMixin
                 _ => 4096,
             };
 
+            // ThinkingType semantics:
+            //   - explicit "disabled" / "adaptive" / "enabled": honor the user's choice verbatim.
+            //     This lets custom or proxied model names (which the model-id regexes below can't
+            //     recognize) force adaptive thinking, which Claude Opus 4.7/4.8 require.
+            //   - blank/null: auto-detect from the model id (adaptive for 4.6/4.7/4.8, otherwise manual).
             ThinkingConfigParam thinkingConfigParam;
-            if (_owner.ThinkingType?.Equals("disabled", StringComparison.OrdinalIgnoreCase) is true)
+            var thinkingType = _owner.ThinkingType?.Trim();
+            if (string.Equals(thinkingType, "disabled", StringComparison.OrdinalIgnoreCase))
             {
                 thinkingConfigParam = new ThinkingConfigParam(new ThinkingConfigDisabled());
             }
+            else if (string.Equals(thinkingType, "adaptive", StringComparison.OrdinalIgnoreCase))
+            {
+                thinkingConfigParam = new ThinkingConfigParam(new ThinkingConfigAdaptive());
+            }
+            else if (string.Equals(thinkingType, "enabled", StringComparison.OrdinalIgnoreCase))
+            {
+                thinkingConfigParam = new ThinkingConfigParam(new ThinkingConfigEnabled { BudgetTokens = GetBudgetTokens() });
+            }
+            else if (_isClaude46 || _isClaude47 || _isClaude48)
+            {
+                // Adaptive models don't support budgetTokens, so ThinkingBudget is ignored for them.
+                thinkingConfigParam = new ThinkingConfigParam(new ThinkingConfigAdaptive());
+            }
             else
             {
-                // Only Claude 4.6 and 4.7 supports adaptive and don't support budgetTokens so we ignore ThinkingBudget for them.
-                if (_isClaude46 || _isClaude47)
-                {
-                    thinkingConfigParam = new ThinkingConfigParam(new ThinkingConfigAdaptive());
-                }
-                else
-                {
-                    if (!long.TryParse(_owner.ThinkingBudget, out var budgetTokens))
-                    {
-                        budgetTokens = -1L;
-                    }
+                thinkingConfigParam = new ThinkingConfigParam(new ThinkingConfigEnabled { BudgetTokens = GetBudgetTokens() });
+            }
 
-                    thinkingConfigParam = new ThinkingConfigParam(
-                        new ThinkingConfigEnabled
-                        {
-                            BudgetTokens = Math.Max(budgetTokens, 2048)
-                        });
+            long GetBudgetTokens()
+            {
+                if (!long.TryParse(_owner.ThinkingBudget, out var budgetTokens))
+                {
+                    budgetTokens = -1L;
                 }
+
+                return Math.Max(budgetTokens, 2048);
             }
 
             OutputConfig? outputConfig = null;
@@ -166,7 +180,7 @@ public sealed partial class AnthropicKernelMixin : KernelMixin
         /// - AWS Bedrock: anthropic.claude-opus-4-6-v1
         /// - GCP Vertex AI: claude-opus-4-6
         /// </summary>
-        [GeneratedRegex(@"(?:anthropic\.)?claude-(?:opus|sonnet)-4[.-]6(?:[@\-:][\w\-:]+)?$")]
+        [GeneratedRegex(@"(?:anthropic\.)?claude-(?:opus|sonnet)-4[.-]6(?:[@\-:][\w\-:]+)?$", RegexOptions.IgnoreCase)]
         private static partial Regex Claude46Regex();
         
         /// <summary>
@@ -174,7 +188,14 @@ public sealed partial class AnthropicKernelMixin : KernelMixin
         /// 4.7 rejects temperature/top_p/top_k and natively supports xhigh reasoning effort.
         /// </summary>
         /// <returns></returns>
-        [GeneratedRegex(@"(?:anthropic\.)?claude-opus-4[.-]7(?:[@\-:][\w\-:]+)?$")]
+        [GeneratedRegex(@"(?:anthropic\.)?claude-opus-4[.-]7(?:[@\-:][\w\-:]+)?$", RegexOptions.IgnoreCase)]
         private static partial Regex Claude47Regex();
+
+        /// <summary>
+        /// Check if the model is Claude Opus 4.8. Like 4.7, it only supports adaptive thinking;
+        /// manual <c>enabled</c> + <c>budget_tokens</c> is rejected with a 400.
+        /// </summary>
+        [GeneratedRegex(@"(?:anthropic\.)?claude-opus-4[.-]8(?:[@\-:][\w\-:]+)?$", RegexOptions.IgnoreCase)]
+        private static partial Regex Claude48Regex();
     }
 }

--- a/src/Everywhere.Core/AI/Assistant/Assistant.cs
+++ b/src/Everywhere.Core/AI/Assistant/Assistant.cs
@@ -116,7 +116,7 @@ public abstract partial class Assistant : ObservableValidator, IModelDefinition
     [JsonIgnore]
     [SettingsItemIgnore]
 #pragma warning disable CA1822 // Required non-static for binding, TODO: make source generator more robust, use ActualType.StaticProperty instead of Path
-    public string?[] ReasoningEnabledOptions { get; } = [null, "enabled", "disabled"];
+    public string?[] ReasoningEnabledOptions { get; } = [null, "adaptive", "enabled", "disabled"];
 #pragma warning restore CA1822
 
     [ObservableProperty]

--- a/src/Everywhere.Core/I18N/Strings.resx
+++ b/src/Everywhere.Core/I18N/Strings.resx
@@ -2675,7 +2675,7 @@ Use scroll wheel or number keys to switch selection mode</value>
         <value>Thinking Type (thinking.type)</value>
     </data>
     <data name="Assistant_ThinkingType_Description" xml:space="preserve">
-        <value>For models that support dynamic reasoning toggling, this option can be used to disable model reasoning. Leaving it blank means this parameter will not be included in the request.</value>
+        <value>Sets thinking.type. Leave blank to auto-select by model ID (adaptive for Claude Opus 4.6/4.7/4.8 and Sonnet 4.6, otherwise manual budget). Choose adaptive, enabled, or disabled to force a mode — needed for custom or proxied model names that cannot be auto-detected. Claude Opus 4.7/4.8 only support adaptive.</value>
     </data>
     <data name="Assistant_ThinkingBudget_Header" xml:space="preserve">
         <value>Thinking Budget (thinking_budget)</value>

--- a/src/Everywhere.Core/I18N/Strings.zh-hans.resx
+++ b/src/Everywhere.Core/I18N/Strings.zh-hans.resx
@@ -2676,7 +2676,7 @@
         <value>思考类型 (thinking.type)</value>
     </data>
     <data name="Assistant_ThinkingType_Description" xml:space="preserve">
-        <value>对于支持动态开关思考的模型，可以使用此选项关闭模型思考。留空表示不在请求中包含此参数。</value>
+        <value>设置 thinking.type。留空则按模型 ID 自动选择（Claude Opus 4.6/4.7/4.8 与 Sonnet 4.6 使用 adaptive，其余使用固定预算 manual）。选择 adaptive、enabled 或 disabled 可强制指定模式——适用于无法自动识别的自定义或中转模型名。Claude Opus 4.7/4.8 仅支持 adaptive。</value>
     </data>
     <data name="Assistant_ThinkingBudget_Header" xml:space="preserve">
         <value>思考预算 (thinking_budget)</value>


### PR DESCRIPTION
Closes #410

## Summary
- Add `Claude48Regex` to detect Opus 4.8 model IDs
- Restructure thinking type logic: explicit user choice (`disabled`/`adaptive`/`enabled`) takes priority over model auto-detection
- Add `"adaptive"` to the Thinking Type UI dropdown
- Make model-detection regexes case-insensitive (`RegexOptions.IgnoreCase`)
- Update ThinkingType description in EN/ZH-CN to explain the auto-select behavior

## Test plan
- Select Claude Opus 4.8, leave Thinking Type blank → should auto-select adaptive (no 400 error)
- Explicitly choose adaptive/enabled/disabled → should honor user choice
- Claude 4.6/4.7 models should continue to work as before