### PR TITLE
fix: ensure emoji dictionary loads for English locale

### DIFF
--- a/src/Everywhere.Core/Views/Controls/IconEditor.axaml.cs
+++ b/src/Everywhere.Core/Views/Controls/IconEditor.axaml.cs
@@ -226,7 +226,7 @@ public sealed class IconEditor : TemplatedControl
                     }
                     if (locale == LocaleName.En)
                     {
-                        return null;
+                        return defaultData;
                     }
 
                     var localizedUri = new Uri(


### PR DESCRIPTION
## Description
Fixes an issue where emojis were not loading when the app was set to English. The root cause was that the function returned `null` for the English locale, which prevented the default emoji data from being applied.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation update
- [ ] CI/CD or Build changes

## Current Behavior
When the app is set to English (`LocaleName.En`), the function returns `null`, causing emojis to fail loading.

## Updated/Expected Behavior
When the app is set to English (`LocaleName.En`), the function now returns `defaultData`, ensuring emojis load correctly. Test by switching the app to English and verifying that emojis appear as expected.

## Implementation Details
The fix is minimal: changed the return value from `null` to `defaultData` for the English locale case. This ensures the default emoji data is used when no locale-specific data is available.

## Checklist
- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [ ] I have added XML documentation to any related classes