### PR TITLE
fix(docs): restore the broken star history chart

### DIFF
--- a/README-ja-jp.md
+++ b/README-ja-jp.md
@@ -234,11 +234,11 @@ Copyright © 2026 Sylinko Inc. All rights reserved.
 
 <br/>
 
-<a href="https://www.star-history.com/?type=date&repos=Sylinko%2FEverywhere">
+<a href="https://star-history.dera.page/#Sylinko/Everywhere&type=date">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=Sylinko/Everywhere&type=date&theme=dark&legend=top-left" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=Sylinko/Everywhere&type=date&legend=top-left" />
-   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=Sylinko/Everywhere&type=date&legend=top-left" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=Sylinko/Everywhere&type=date&theme=dark&legend=top-left" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=Sylinko/Everywhere&type=date&legend=top-left" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=Sylinko/Everywhere&type=date&legend=top-left" />
  </picture>
 </a>
 

--- a/README-zh-cn.md
+++ b/README-zh-cn.md
@@ -235,11 +235,11 @@ Copyright © 2026 Sylinko Inc. 保留所有权利。
 
 <br/>
 
-<a href="https://www.star-history.com/?type=date&repos=Sylinko%2FEverywhere">
+<a href="https://star-history.dera.page/#Sylinko/Everywhere&type=date">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=Sylinko/Everywhere&type=date&theme=dark&legend=top-left" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=Sylinko/Everywhere&type=date&legend=top-left" />
-   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=Sylinko/Everywhere&type=date&legend=top-left" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=Sylinko/Everywhere&type=date&theme=dark&legend=top-left" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=Sylinko/Everywhere&type=date&legend=top-left" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=Sylinko/Everywhere&type=date&legend=top-left" />
  </picture>
 </a>
 

--- a/README.md
+++ b/README.md
@@ -234,11 +234,11 @@ Thanks [pasical](https://github.com/pasical) for the banner kawaii logo design.
 
 <br/>
 
-<a href="https://www.star-history.com/?type=date&repos=Sylinko%2FEverywhere">
+<a href="https://star-history.dera.page/#Sylinko/Everywhere&type=date">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=Sylinko/Everywhere&type=date&theme=dark&legend=top-left" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=Sylinko/Everywhere&type=date&legend=top-left" />
-   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=Sylinko/Everywhere&type=date&legend=top-left" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=Sylinko/Everywhere&type=date&theme=dark&legend=top-left" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=Sylinko/Everywhere&type=date&legend=top-left" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=Sylinko/Everywhere&type=date&legend=top-left" />
  </picture>
 </a>
 


### PR DESCRIPTION
The star history chart is currently broken and no longer renders. This change restores it across the main, Chinese, and Japanese READMEs using a working provider that requires no API token, so the chart is visible again.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Star History chart links in the English, Japanese, and Simplified Chinese README files.
  * Chart embeds now use the `star-history.dera.page` SVG endpoints with separate dark and light theme sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->